### PR TITLE
Handle "enter" keycode 13

### DIFF
--- a/re-search.c
+++ b/re-search.c
@@ -374,6 +374,7 @@ int main() {
 			break;
 
 		case 10: // enter
+		case 13: // new-line
 			accept(RESULT_EXECUTE);
 			break;
 


### PR DESCRIPTION
Pressing "enter" to accept a command stopped working. Upon debug it seems my terminal now generates code 13 for 'Enter'. Seems sensible to support both.