### PR TITLE
Change color and keybinding for subsearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For example, you are looking for the git-clone command of couchbase repository,
 the following sequence shows how it could help you:
 
 * [C-r] clone
-* [C-u]
+* [C-q]
 * couchbase
 
 ### Internal key bindings
@@ -42,7 +42,7 @@ the following sequence shows how it could help you:
 * C-s, down, pg-down: forward search.
 * C-c, C-g, left, esc, home: cancel search.
 * C-e, right, end: accept result.
-* C-u: save search result and start sub-search.
+* C-q: save search result and start sub-search.
 * Enter: execute result.
 
 ### Customize the prompt

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ the following sequence shows how it could help you:
 * C-c, C-g, left, esc, home: cancel search.
 * C-e, right, end: accept result.
 * C-q: save search result and start sub-search.
+* C-u: delete the current search term
 * Enter: execute result.
 
 ### Customize the prompt

--- a/re-search.c
+++ b/re-search.c
@@ -49,8 +49,12 @@
 #ifndef PROMPT
 #define PROMPT(buffer, saved, direction, index, result) \
 	do { \
-		/* print the first part of the prompt */ \
-		fprintf(stderr, "%s<%s search> %s%s", saved, direction, CYAN, buffer); \
+		/* print the subsearch */ \
+		fprintf(stderr, "%s%s", CYAN, saved); \
+		/* print the direction  */ \
+		fprintf(stderr, "%s<%s search> ", search_index > 0 ? GREEN : RED, direction); \
+		/* print the search buffer */ \
+		fprintf(stderr, "%s%s", CYAN, buffer); \
 		if (index > 0) { \
 			/* save cursor position */ \
 			fprintf(stderr, "\033[s"); \
@@ -344,9 +348,6 @@ int main() {
 
 		// erase line
 		fprintf(stderr, "\033[2K\r");
-
-		// print the color
-		fprintf(stderr, "%s", search_index > 0 ? GREEN : RED);
 
 		// print the prompt
 		PROMPT(buffer, saved, (action == SEARCH_BACKWARD ? "backward" : "forward"),

--- a/re-search.c
+++ b/re-search.c
@@ -415,7 +415,7 @@ int main() {
 			action = SEARCH_FORWARD;
 			break;
 
-		case 21: //C-u
+		case 17: //C-q
 			if (strlen(buffer) == 0)
 				break;
 			j = 0;

--- a/re-search.c
+++ b/re-search.c
@@ -445,6 +445,17 @@ int main() {
 			search_index = 0;
 			break;
 
+		case 21: // C-u
+			buffer[0] = '\0';
+			buffer_pos = 0;
+
+			// reset search
+			action = SEARCH_BACKWARD;
+			search_result_index = history_size;
+			search_index = 0;
+
+			break;
+
 		case 127: // backspace
 		case 8: // backspace
 			if (buffer_pos > 0)


### PR DESCRIPTION
## Switched sub-search keybinding from Ctrl-u to Ctrl-q

Ctrl-u is a default readline binding to delete from the cursor to the
beginning of the line. Therefore it should not be used for a different
purpose, but instead should execute such readline functionality (which
re-search currently doesn't).

Ctrl-q is a safer key binding.

## Provide Ctrl-u keybinding to delete search-term

Ctrl-u is a standard readline keybinding to delete from the current
cursor position to the beginning of the line.
Since re-search does not support moving the cursor it always deletes
from the end of the line to the beginning of the line.

## Print subsearch in different color

This makes it easier to distinguish it from the search direction.
