### PR TITLE
Add Ctrl-L binding to clear screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ the following sequence shows how it could help you:
 * C-c, C-g, left, esc, home: cancel search.
 * C-e, right, end: accept result.
 * C-u: save search result and start sub-search.
+* C-l: clear screen
 * Enter: execute result.
 
 ### Customize the prompt

--- a/re-search.c
+++ b/re-search.c
@@ -402,6 +402,13 @@ int main() {
 			accept(RESULT_EDIT);
 			break;
 
+		case 12: // C-l
+			// erase line
+			fprintf(stderr, "\033[2J");
+			// jump to upper left corner
+			fprintf(stderr, "\033[1;1H");
+			break;
+
 		case 10: // enter
 		case 13: // new-line
 			accept(RESULT_EXECUTE);


### PR DESCRIPTION
Ctrl-L is the default binding to clear the screen.
This commit lets re-search behave like bashs integrated history search
when Ctrl-L is pressed