### PR TITLE
Implement Ctrl-w to delete a word backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ the following sequence shows how it could help you:
 * C-l: clear screen
 * C-q: save search result and start sub-search.
 * C-u: delete the current search term
+* C-w: delete a word backwards
 * Enter: execute result.
 
 ### Customize the prompt

--- a/re-search.c
+++ b/re-search.c
@@ -464,6 +464,26 @@ int main() {
 
 			break;
 
+		case 23: // C-w
+			i = 0; // i == 1 means we have reached a non-space character
+			while (buffer_pos > 0) {
+				if (buffer[--buffer_pos] != ' ') {
+					i= 1;
+				} else if (i == 1) {
+					// stop at next space
+					buffer_pos++;
+					break;
+				}
+			}
+			buffer[buffer_pos] = '\0';
+
+			// reset search
+			action = SEARCH_BACKWARD;
+			search_result_index = history_size;
+			search_index = 0;
+
+			break;
+
 		case 127: // backspace
 		case 8: // backspace
 			if (buffer_pos > 0)


### PR DESCRIPTION
Ctrl-w is a standard readline keybinding to delete a word to the left.
This commit implements this functionality. It deletes the characters to
left of the cursor until a space is reached. Spaces between the cursor
and the next word are deleted, too.