### PR TITLE
Implement ctrl-p and ctrl-n to cycle through history

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ the following sequence shows how it could help you:
 * C-q: save search result and start sub-search.
 * C-u: delete the current search term
 * C-w: delete a word backwards
+* C-p: cycle through history backwards
+* C-n: cycle through history forwards
 * Enter: execute result.
 
 ### Customize the prompt


### PR DESCRIPTION
Ctrl-p and Ctrl-n can now be used to cycle through the history like the
default bindings in fish shell itself (and bash).

If a search was already performed, the cycling will start at that
history entry.

The default PROMPT macro was modified to support a different
visualization when cycling through history. No direction and no search
index will be printed while cycling.