### PR TITLE
Implement Ctrl-o to execute a line from history and jump to the next entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ the following sequence shows how it could help you:
 * C-c, C-g, left, esc, home: cancel search.
 * C-e, right, end: accept result.
 * C-l: clear screen
+* C-o: execute current entry and jump the next one in history.
 * C-q: save search result and start sub-search.
 * C-u: delete the current search term
 * C-w: delete a word backwards

--- a/re-search.c
+++ b/re-search.c
@@ -530,6 +530,14 @@ int main(int argc, char **argv) {
 			search_index = 0;
 			break;
 
+		case 24: //C-x
+			if (no_of_subsearches == 0)
+				break;
+
+			no_of_subsearches--;
+
+			break;
+
 		case 21: // C-u
 			buffer[0] = '\0';
 			buffer_pos = 0;

--- a/re-search.c
+++ b/re-search.c
@@ -283,8 +283,15 @@ void execute(char *cmdline) {
 void append_to_history(char *cmdline) {
 	if (history_size >= MAX_HISTORY_SIZE) {
 		error("too many history entries");
+		return;
 	}
+
 	int len = strlen(cmdline);
+	if (!malloc(len + 1)) {
+		error("cannot allocate memory");
+		return;
+	}
+
 	history[history_size] = malloc(len + 1);
 	strncpy(history[history_size], cmdline, len + 1);
 	history_size++;

--- a/re-search.c
+++ b/re-search.c
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <fcntl.h>
 #include "config.h"
+#include <sys/wait.h>
 
 #define NORMAL  "\x1B[0m"
 #define RED  "\x1B[31m"
@@ -64,6 +65,10 @@
 				action_str = ""; \
 				action_color = CYAN; \
 				break; \
+			case EXECUTE: \
+				action_str= "execute"; \
+				action_color = CYAN; \
+				break; \
 			default: \
 				action_str = "??"; \
 				action_color = RED; \
@@ -97,7 +102,7 @@
 #endif /* BASH */
 
 typedef enum {
-	SEARCH_BACKWARD, SEARCH_FORWARD, SCROLL,
+	SEARCH_BACKWARD, SEARCH_FORWARD, SCROLL, EXECUTE,
 } action_t;
 
 /* will be used as exit code to differenciate cases */
@@ -111,6 +116,8 @@ char buffer[MAX_INPUT_LEN];
 char saved[128];
 unsigned long history_size;
 int search_result_index;
+FILE *outfile;
+
 
 void reset_input_mode() {
 	debug("restore terminal settings");
@@ -259,6 +266,30 @@ int parse_history() {
 	return 0;
 }
 
+void execute(char *cmdline) {
+	// Execute commandline in a separate child process
+	int cpid = fork();
+	if (cpid == 0) {
+		reset_input_mode();
+		// print the line to execute
+		fprintf(stdout, "%s$ %s%s\n", CYAN, cmdline, NORMAL);
+		// then execute it
+		execl(getenv("SHELL"), getenv("SHELL"), "-c", cmdline, NULL);
+	}
+	wait(&cpid);
+	set_input_mode();
+}
+
+void append_to_history(char *cmdline) {
+	if (history_size >= MAX_HISTORY_SIZE) {
+		error("too many history entries");
+	}
+	int len = strlen(cmdline);
+	history[history_size] = malloc(len + 1);
+	strncpy(history[history_size], cmdline, len + 1);
+	history_size++;
+}
+
 void restore_terminal() {
 	// reset color
 	fprintf(stderr, "%s", NORMAL);
@@ -305,7 +336,7 @@ void cleanup() {
 
 void accept(int status) {
 	// print result/buffer to stdout
-	fprintf(stdout, "%s",
+	fprintf(outfile, "%s",
 			search_result_index < history_size ?
 					history[search_result_index] : buffer);
 	cleanup();
@@ -317,7 +348,17 @@ void cancel() {
 	exit(SEARCH_CANCEL);
 }
 
-int main() {
+int main(int argc, char **argv) {
+	// write either to stdout or the given file
+	if (argc == 1) {
+		outfile = stdout;
+	} else if (argc == 2) {
+		outfile = fopen(argv[1], "w");
+	} else {
+		error("The only (optional) valid parameter is the path to the file to write the result to.");
+		return 1;
+	}
+
 	// ensure everything is initialized
 	buffer[0] = '\0';
 	history_size = 0;
@@ -553,6 +594,24 @@ int main() {
 			// reset search
 			action = SEARCH_BACKWARD;
 			search_result_index = history_size;
+			search_index = 0;
+
+			break;
+
+		case 15: // ctrl-o
+			restore_terminal();
+			char *cmdline = search_result_index < history_size ? history[search_result_index] : buffer;
+
+			execute(cmdline);
+			append_to_history(cmdline);
+
+			// we don't need the buffer contents in execute mode
+			buffer[0] = '\0';
+			buffer_pos = 0;
+
+			// jump to next history entry
+			action = EXECUTE;
+			search_result_index++;
 			search_index = 0;
 
 			break;

--- a/re-search.c
+++ b/re-search.c
@@ -425,7 +425,7 @@ int main(int argc, char **argv) {
 						break;
 					}
 				}
-			} else {
+			} else if (action == SEARCH_FORWARD) {
 				for (i = search_result_index + 1; i < history_size; i++) {
 					if (matches_all_searches(history[i])) {
 						search_index--;

--- a/re-search.c
+++ b/re-search.c
@@ -415,6 +415,18 @@ int main(int argc, char **argv) {
 	int noop = 0;
 	while (1) {
 		if (!noop && (buffer_pos > 0 || no_of_subsearches > 0)) {
+			if (search_index < 0 && (action == SEARCH_BACKWARD || action == SEARCH_FORWARD)) {
+				// recalculate the number of matching entries up to the current
+				// history index. May be necessary after a SCROLL action
+				debug("Recalculating search_index");
+				search_index = 0;
+				for (i = history_size - 1;  i > search_result_index - 1; i--) {
+					if (matches_all_searches(history[i])) {
+						search_index++;
+					}
+				}
+			}
+
 			// search in the history array
 			// TODO: factorize?
 			if (action == SEARCH_BACKWARD) {
@@ -577,7 +589,7 @@ int main(int argc, char **argv) {
 			buffer[0] = '\0';
 			buffer_pos = 0;
 			action = SCROLL;
-			search_index = 0;
+			search_index = -1;
 
 			break;
 
@@ -589,7 +601,7 @@ int main(int argc, char **argv) {
 			buffer[0] = '\0';
 			buffer_pos = 0;
 			action = SCROLL;
-			search_index = 0;
+			search_index = -1;
 
 			break;
 

--- a/re-search.c
+++ b/re-search.c
@@ -280,23 +280,6 @@ void execute(char *cmdline) {
 	set_input_mode();
 }
 
-void append_to_history(char *cmdline) {
-	if (history_size >= MAX_HISTORY_SIZE) {
-		error("too many history entries");
-		return;
-	}
-
-	int len = strlen(cmdline);
-	if (!malloc(len + 1)) {
-		error("cannot allocate memory");
-		return;
-	}
-
-	history[history_size] = malloc(len + 1);
-	strncpy(history[history_size], cmdline, len + 1);
-	history_size++;
-}
-
 void restore_terminal() {
 	// reset color
 	fprintf(stderr, "%s", NORMAL);

--- a/re_search.fish
+++ b/re_search.fish
@@ -1,7 +1,7 @@
 function re_search
 	set -l tmp (mktemp -t fish.XXXXXX)
 	set -x SEARCH_BUFFER (commandline -b)
-	re-search > $tmp
+	re-search $tmp
 	set -l res $status
 	commandline -f repaint
 	if [ -s $tmp ]


### PR DESCRIPTION
This commit replicates bashs binding to Ctrl-o.

Ctrl-o exists in bash to execute a command from the history (as Enter
does), but then display the next entry from the history. Another press
of Ctrl-o then executes that next line and displays the entry after it.

For example if the are the following entries in the history:

  echo 1
  echo 2
  echo 3

and the entry "echo 1" is the currently selected entry in re-search,
Ctrl-o would execute "echo 1" and then display "echo 2". Another press
of Ctrl-o would display "echo 3" and so on.

This allows repeating the same sequence of commands in history just by
pressing Ctrl-o multiple times.

To allow for displaying the result of the executed commands while still
inside re-search, the corresponding fish function needed to be changed
to specify the temporary file containing the line to execute as an
argument to re-search instead of always printing to stdout and using
redirection.

This PR depends on #20.