### PR TITLE
Ignore unknow control keys

### DIFF
--- a/re-search.c
+++ b/re-search.c
@@ -323,8 +323,9 @@ int main() {
 	// disable line wrapping
 	fprintf(stderr, "\033[?7l");
 
+	int noop = 0;
 	while (1) {
-		if (buffer_pos > 0 || strlen(saved) > 0) {
+		if (!noop && (buffer_pos > 0 || strlen(saved) > 0)) {
 			// search in the history array
 			// TODO: factorize?
 			if (action == SEARCH_BACKWARD) {
@@ -345,6 +346,7 @@ int main() {
 				}
 			}
 		}
+		noop = 0;
 
 		// erase line
 		fprintf(stderr, "\033[2K\r");
@@ -497,9 +499,11 @@ int main() {
 			break;
 
 		default:
-			// exclude the first 32 non-printing characters
-			if (c < 32)
+			// ignore the first 32 non-printing characters
+			if (c < 32) {
+				noop = 1;
 				break;
+			}
 
 			// prevent buffer overflow
 			if (buffer_pos >= MAX_INPUT_LEN - 1)


### PR DESCRIPTION
Unknown control keys (the first 32 non-printin characters) were
interpreted as executing a search.

This commit changes those keys to being a noop, therefore leading a
saner behaviour.

Closes: #18