### PR TITLE
Correct sanitation of newlines

### DIFF
--- a/re-search.c
+++ b/re-search.c
@@ -167,10 +167,15 @@ int parse_history() {
 		// sanitize
 		i = CMD_PREFIX_LEN; j = 0;
 		while (i < len) {
-			if (i < (len - 1) && cmdline[i] == '\\' && cmdline[i+1] == '\\') {
+			if (cmdline[i] == '\\' && cmdline[j-1] == '\\') {
+				j--;
+			} else if (i < (len -1) && cmdline[i] == '\\' && cmdline[i + 1] == 'n') {
+				cmdline[j] = '\n';
 				i++;
+			} else {
+				cmdline[j] = cmdline[i];
 			}
-			cmdline[j] = cmdline[i];
+
 			i++; j++;
 		}
 		cmdline[j] = '\0';

--- a/re-search.c
+++ b/re-search.c
@@ -167,7 +167,7 @@ int parse_history() {
 		// sanitize
 		i = CMD_PREFIX_LEN; j = 0;
 		while (i < len) {
-			if (cmdline[i] == '\\' && cmdline[j-1] == '\\') {
+			if (j > 0 && cmdline[i] == '\\' && cmdline[j-1] == '\\') {
 				j--;
 			} else if (i < (len -1) && cmdline[i] == '\\' && cmdline[i + 1] == 'n') {
 				cmdline[j] = '\n';


### PR DESCRIPTION
Fish stores newline characters as strings in its history file.
This commit corrects the handling of such newline characters to convert
them to real newline characters again.

If the newline character is escaped with a backslash it will still be
treated as a string and only the escaping backslash is removed (as was
already the case).

For the example the previous implementation would convert this:

```
  for f in *.pdf
    echo -e "\t$f\n"
  end
```

to this:

```
  for f in *.pdf\necho -e "\t$f\n"\nend
```

This commit corrects this and converts it to this:

```
  for f in *.pdf
  echo -e "\t$f\n"
  end
```

No other control characters, apart from newline, are handled specially.
But I am also not aware of any way of inserting such literal control
characters in fish.