### PR TITLE
Fix dropping oldest history entries

### DIFF
--- a/re-search.c
+++ b/re-search.c
@@ -157,6 +157,7 @@ int append_to_history(const char *cmdline) {
 			history[i-1] = history[i];
 		}
 		history[history_size] = NULL; //empty the last element pointer
+		history_size--;
 	}
 
 	// append to history array


### PR DESCRIPTION
This fixes a bug on dropping the oldest history entries if
MAX_HISTORY_SIZE is reached that would drop the wrong entries.