### PR TITLE
Support specifying start index via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ the following sequence shows how it could help you:
 * [C-q]
 * couchbase
 
+#### Enable bash-like history scrolling
+
+By default fish does not scroll the history buffer on "up" an "C-p", but
+instead executes a search with the current commandline content as search
+string.
+
+To enable the usual scrolling regardless of the current content of the
+commandline copy the file `re_search_scroll.fish` to the directory
+`~/.config/fish/functions/` and add a binding to
+`~/.config/fish/functions/fish_user_key_bindings.fish`:
+```
+bind \cp re_search_scroll
+```
+to bind it to "Ctrl-p" or
+```
+bind \e\[A re_search_scroll
+```
+to bind it to the "Up" arrow.
+
 ### Internal key bindings
 
 * C-r, up, pg-up: backward search.

--- a/re-search.c
+++ b/re-search.c
@@ -355,6 +355,19 @@ int main() {
 			buffer[--buffer_pos] = '\0';
 	}
 
+	// if the start index environment variable is set, jump to the
+	// corresponding history entry
+	char* start_index = getenv("START_INDEX");
+	if (start_index && strlen(start_index) > 0) {
+		int idx= strtol(start_index, NULL, 10);
+		search_result_index = history_size - idx;
+		action = SCROLL;
+
+		// ignore $SEARCH_BUFFER
+		buffer[0] = '\0';
+		buffer_pos = 0;
+	}
+
 	// disable line wrapping
 	fprintf(stderr, "\033[?7l");
 

--- a/re_search_scroll.fish
+++ b/re_search_scroll.fish
@@ -1,0 +1,4 @@
+function re_search_scroll
+	set -x START_INDEX 1
+	re_search
+end


### PR DESCRIPTION
The environment variable `START_INDEX` is used to specify the start
index for a scroll event.

This allows binding a key to start scrolling the history backwards even
if there is some content in the current commandline (a case which is not
supported in fish itself). The rationale for doing so is described in
https://github.com/fish-shell/fish-shell/issues/1671 and
https://github.com/fish-shell/fish-shell/issues/1668.

A fish function is provided for binding that behaviour to a key (like
Ctrl-p or the Up arrow).